### PR TITLE
make project property optional

### DIFF
--- a/src/main/java/org/sonar/plugins/resharper/ReSharperExecutor.java
+++ b/src/main/java/org/sonar/plugins/resharper/ReSharperExecutor.java
@@ -30,11 +30,11 @@ public class ReSharperExecutor {
 
   private static final String EXECUTABLE = "inspectcode.exe";
 
-  public void execute(String executable, String project, String solutionFile, File rulesetFile, File reportFile, int timeout) {
+  public void execute(String executable, String projectArg, String solutionFile, File rulesetFile, File reportFile, int timeout) {
     Command cmd = Command.create(getExecutable(executable))
       .addArgument("/output=" + reportFile.getAbsolutePath())
       .addArgument("/no-swea")
-      .addArgument("/project=" + project)
+      .addArgument(projectArg)
       .addArgument("/profile=" + rulesetFile.getAbsolutePath())
       .addArgument("/no-buildin-settings")
       .addArgument(solutionFile);

--- a/src/test/java/org/sonar/plugins/resharper/ReSharperSensorTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/ReSharperSensorTest.java
@@ -150,7 +150,7 @@ public class ReSharperSensorTest {
 
     verify(writer).write(ImmutableList.of("AccessToDisposedClosure", "AccessToForEachVariableInClosure"), new File(workingDir, "resharper-sonarqube.DotSettings"));
     verify(executor).execute(
-      "inspectcode.exe", "MyLibrary", "CSharpPlayground.sln",
+      "inspectcode.exe", "/project=MyLibrary", "CSharpPlayground.sln",
       new File(workingDir, "resharper-sonarqube.DotSettings"), new File(workingDir, "resharper-report.xml"), 10);
 
     verify(issuable).addIssue(issue1);
@@ -161,15 +161,6 @@ public class ReSharperSensorTest {
 
     verify(issueBuilder2).line(5);
     verify(issueBuilder2).message("Third message");
-  }
-
-  @Test
-  public void check_project_name_property() {
-    thrown.expectMessage(ReSharperPlugin.PROJECT_NAME_PROPERTY_KEY);
-    thrown.expect(IllegalStateException.class);
-
-    Settings settings = mockSettings(null, "dummy.sln", null);
-    mockReSharperSensor(settings).analyse(mock(Project.class), mock(SensorContext.class));
   }
 
   @Test


### PR DESCRIPTION
when setting vs boot straper to disable is convenient to run resharper only once in the solution instead if defining modules manually. this can be easily done by just not setting /project.

this means also that we dont need to define modules and all the files will be indexed easily.

can you please consider this enhancement please.

Style cop already supports this if instead of defining the project we choose the solution than stylecop runs in all project. resharper should behave similiar.

Fxcop works, but might need some enahcment to support definition of several assemblies to be checked.