### PR TITLE
prevent duplicates issues to show up in sonar

### DIFF
--- a/src/main/java/org/sonar/plugins/resharper/ReSharperReportParser.java
+++ b/src/main/java/org/sonar/plugins/resharper/ReSharperReportParser.java
@@ -94,7 +94,22 @@ public class ReSharperReportParser {
       String filePath = getAttribute("File");
       Integer line = getIntAttribute("Line");
       String message = getRequiredAttribute("Message");
-      filesBuilder.add(new ReSharperIssue(stream.getLocation().getLineNumber(), typeId, filePath, line, message));
+      ReSharperIssue uniqueIssue = new ReSharperIssue(stream.getLocation().getLineNumber(), typeId, filePath, line, message);
+      for(ReSharperIssue issue : filesBuilder.build()) {
+        if (issue.ruleKey().equals(issue.ruleKey())
+                && issue.filePath().equals(uniqueIssue.filePath())
+                && issue.message().equals(uniqueIssue.message())) {          
+          if(issue.line() == null) {           
+            return;
+          } else {
+            if(issue.line().equals(uniqueIssue.line())) {
+              return;
+            }          
+          }          
+        }
+      }
+      
+      filesBuilder.add(uniqueIssue);
     }
 
     private String getRequiredAttribute(String name) {


### PR DESCRIPTION
for some reasons we got duplicated issues showing up in sonar, solved by ensuring only a unique issue is created 