### PR TITLE
allow configuration of whether to use /no-buildin-settings switch

### DIFF
--- a/src/main/java/org/sonar/plugins/resharper/ReSharperExecutor.java
+++ b/src/main/java/org/sonar/plugins/resharper/ReSharperExecutor.java
@@ -30,13 +30,18 @@ public class ReSharperExecutor {
 
   private static final String EXECUTABLE = "inspectcode.exe";
 
-  public void execute(String executable, String project, String solutionFile, File rulesetFile, File reportFile, int timeout) {
+  public void execute(String executable, String project, String solutionFile, File rulesetFile, File reportFile, int timeout, Boolean useBuiltInSettings) {
     Command cmd = Command.create(getExecutable(executable))
-      .addArgument("/output=" + reportFile.getAbsolutePath())
-      .addArgument("/no-swea")
-      .addArgument("/project=" + project)
-      .addArgument("/profile=" + rulesetFile.getAbsolutePath())
-      .addArgument("/no-buildin-settings")
+            .addArgument("/output=" + reportFile.getAbsolutePath())
+            .addArgument("/no-swea")
+            .addArgument("/project=" + project)
+            .addArgument("/profile=" + rulesetFile.getAbsolutePath());
+
+    if (!useBuiltInSettings){
+      cmd = cmd.addArgument("/no-buildin-settings");
+    }
+
+    cmd = cmd
       .addArgument(solutionFile);
 
     int exitCode = CommandExecutor.create().execute(cmd, TimeUnit.MINUTES.toMillis(timeout));

--- a/src/main/java/org/sonar/plugins/resharper/ReSharperPlugin.java
+++ b/src/main/java/org/sonar/plugins/resharper/ReSharperPlugin.java
@@ -33,6 +33,7 @@ public class ReSharperPlugin extends SonarPlugin {
   public static final String SOLUTION_FILE_PROPERTY_KEY = "sonar.resharper.solutionFile";
   public static final String INSPECTCODE_PATH_PROPERTY_KEY = "sonar.resharper.inspectCodePath";
   public static final String TIMEOUT_MINUTES_PROPERTY_KEY = "sonar.resharper.timeoutMinutes";
+  public static final String USE_BUILT_IN_SETTINGS_PROPERTY_KEY = "sonar.resharper.useBuiltInSettings";
 
   public static final String OLD_INSTALL_DIRECTORY_KEY = "sonar.resharper.installDirectory";
 
@@ -85,6 +86,15 @@ public class ReSharperPlugin extends SonarPlugin {
         .category(CATEGORY)
         .onQualifiers(Qualifiers.PROJECT)
         .type(PropertyType.INTEGER)
+        .build(),
+
+      PropertyDefinition.builder(USE_BUILT_IN_SETTINGS_PROPERTY_KEY)
+        .name("Use custom settings layers from solution")
+        .description("")
+        .defaultValue("false")
+        .category(CATEGORY)
+        .onQualifiers(Qualifiers.PROJECT)
+        .type(PropertyType.BOOLEAN)
         .build(),
 
       deprecatedPropertyDefinition(OLD_INSTALL_DIRECTORY_KEY));

--- a/src/main/java/org/sonar/plugins/resharper/ReSharperSensor.java
+++ b/src/main/java/org/sonar/plugins/resharper/ReSharperSensor.java
@@ -91,8 +91,13 @@ public class ReSharperSensor implements Sensor {
     File reportFile = new File(fileSystem.workingDir(), "resharper-report.xml");
 
     executor.execute(
-      settings.getString(ReSharperPlugin.INSPECTCODE_PATH_PROPERTY_KEY), settings.getString(ReSharperPlugin.PROJECT_NAME_PROPERTY_KEY),
-      settings.getString(ReSharperPlugin.SOLUTION_FILE_PROPERTY_KEY), rulesetFile, reportFile, settings.getInt(ReSharperPlugin.TIMEOUT_MINUTES_PROPERTY_KEY));
+            settings.getString(ReSharperPlugin.INSPECTCODE_PATH_PROPERTY_KEY),
+            settings.getString(ReSharperPlugin.PROJECT_NAME_PROPERTY_KEY),
+            settings.getString(ReSharperPlugin.SOLUTION_FILE_PROPERTY_KEY),
+            rulesetFile,
+            reportFile,
+            settings.getInt(ReSharperPlugin.TIMEOUT_MINUTES_PROPERTY_KEY),
+            settings.getBoolean(ReSharperPlugin.USE_BUILT_IN_SETTINGS_PROPERTY_KEY));
 
     File solutionFile = new File(settings.getString(ReSharperPlugin.SOLUTION_FILE_PROPERTY_KEY));
     for (ReSharperIssue issue : parser.parse(reportFile)) {

--- a/src/test/java/org/sonar/plugins/resharper/ReSharperPluginTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/ReSharperPluginTest.java
@@ -47,7 +47,7 @@ public class ReSharperPluginTest {
       "sonar.resharper.solutionFile",
       "sonar.resharper.inspectCodePath",
       "sonar.resharper.timeoutMinutes",
-
+      "sonar.resharper.useBuiltInSettings",
       "sonar.resharper.installDirectory");
   }
 

--- a/src/test/java/org/sonar/plugins/resharper/ReSharperSensorTest.java
+++ b/src/test/java/org/sonar/plugins/resharper/ReSharperSensorTest.java
@@ -150,8 +150,13 @@ public class ReSharperSensorTest {
 
     verify(writer).write(ImmutableList.of("AccessToDisposedClosure", "AccessToForEachVariableInClosure"), new File(workingDir, "resharper-sonarqube.DotSettings"));
     verify(executor).execute(
-      "inspectcode.exe", "MyLibrary", "CSharpPlayground.sln",
-      new File(workingDir, "resharper-sonarqube.DotSettings"), new File(workingDir, "resharper-report.xml"), 10);
+            "inspectcode.exe",
+            "MyLibrary",
+            "CSharpPlayground.sln",
+            new File(workingDir, "resharper-sonarqube.DotSettings"),
+            new File(workingDir, "resharper-report.xml"),
+            10,
+            false);
 
     verify(issuable).addIssue(issue1);
     verify(issuable).addIssue(issue2);


### PR DESCRIPTION
InspectCode.exe can hang if it encounters some files that it cannot understand (unknown reason and JetBrains is still to provide a fix). For this reason we have excluded these files from analysis using team-shared configuration on solution level. For this to take effect, we need to skip providing  the /no-buildin-settings switch and read exclusion info from solution level .dotSettings file.

I've left it as default to be provided as earlier, but now we can also allow using of the custom setting layers from solution.

